### PR TITLE
Fix next period getting stuck

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -30,7 +30,8 @@
 					<div class="big" id="current_parent"></div>
 					<div id="next_parent">
 						<div class="divider"></div>
-						<div class="bigish" id="next_period">The next period is {NAME}, which ends at {END}.</div>
+						<template id="next_period_template"> The next period is {NAME}, which ends at {END} </template>
+						<div class="bigish" id="next_period"></div>
 					</div>
 				</div>
 

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -20,6 +20,7 @@ function display(data) {
 	progressIntervals = [];
 
 	if (data[2] && (!data[1] || !data[1][0] || data[1][0].kind !== 'BeforeSchool')) {
+		getel('next_period').innerHTML = getel('next_period_template').innerHTML;
 		put_period_to_element(getel('next_period'), data[2]);
 		getel('next_parent').style.display = 'block';
 	} else {


### PR DESCRIPTION
The next period on the homepage was not updating because the placeholders in the text were removed after the first request. This PR creates a template for that text which is used instead of just getting that element.