### PR TITLE
Extension config fix

### DIFF
--- a/frontend/global/helpers.js
+++ b/frontend/global/helpers.js
@@ -17,17 +17,22 @@ async function get(endpoint = '/api/v1/today/now/near') {
 		.catch(() => null);
 }
 
-const config = Object.assign(
-	{
-		schedule: {},
-		foreground_color: '#1a2741',
-		background_color: '#c34614',
-		foreground_text_color: '#ffffff',
-		background_text_color: '#ffffff',
-		include_period_name: true,
-	},
-	JSON.parse(localStorage.getItem('schedule') || '{}'),
-);
+let config;
+function updateConfig() {
+	config = Object.assign(
+		{
+			schedule: {},
+			foreground_color: '#1a2741',
+			background_color: '#c34614',
+			foreground_text_color: '#ffffff',
+			background_text_color: '#ffffff',
+			include_period_name: true,
+		},
+		JSON.parse(localStorage.getItem('schedule') || '{}'),
+	);
+	return config;
+}
+updateConfig();
 
 function replace_period(period) {
 	if (!period) {
@@ -295,6 +300,7 @@ function setTheme() {
 }
 
 function broadcastConfigToExtension() {
+	updateConfig();
 	if (typeof chrome !== 'undefined' && typeof chrome.runtime !== 'undefined') {
 		chrome.runtime.sendMessage('gbkjjbecehodfeijbdmoieepgmfdlgle', {message: 'schedule', data: JSON.stringify(config)});
 	}

--- a/frontend/global/helpers.js
+++ b/frontend/global/helpers.js
@@ -26,7 +26,7 @@ const config = Object.assign(
 		background_text_color: '#ffffff',
 		include_period_name: true,
 	},
-	JSON.parse(localStorage.getItem('schedule')) || '{}',
+	JSON.parse(localStorage.getItem('schedule') || '{}'),
 );
 
 function replace_period(period) {


### PR DESCRIPTION
This fixes some issues with the config:
1) Initializing the config was using `"{}"` instead of `{}` which was resulting in some funky json (didn't break anything)
2) Updated config wasn't sent to the extension on saving, it sent the old config.

Note that sending to the extension only works when sending from ethsbell.app and to the extension ID in the chrome web store. I was able to test it by using a script override in devtools.