### PR TITLE
Fix for line breaks in literal schedules

### DIFF
--- a/src/ical/event.rs
+++ b/src/ical/event.rs
@@ -96,7 +96,7 @@ impl IcalEvent {
 							let other_lines = vevent
 								.lines()
 								.skip(number + 1)
-								.take_while(|v| v.starts_with('\t'))
+								.take_while(|v| v.starts_with('\t') | v.starts_with(' '))
 								.map(|v| v.trim_start())
 								.collect::<String>();
 							let text = (split.collect::<Vec<&str>>().join(":") + &other_lines)

--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -49,12 +49,18 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 				.unwrap_or(&"".to_string())
 				.starts_with(literal_header)
 			{
+				println!("{}", event.description
+				.as_ref()
+				.unwrap()
+				.to_string()
+				.replace("\n ",""));
+				
 				let json = event
 					.description
 					.as_ref()
 					.unwrap()
 					.to_string()
-					.replace("\n","")
+					.replace("\n ","")
 					.chars()
 					.skip(literal_header.len())
 					.collect::<String>();

--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -49,12 +49,6 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 				.unwrap_or(&"".to_string())
 				.starts_with(literal_header)
 			{
-				println!("{}", event.description
-				.as_ref()
-				.unwrap()
-				.to_string()
-				.replace("\n ",""));
-				
 				let json = event
 					.description
 					.as_ref()

--- a/src/schedule/event.rs
+++ b/src/schedule/event.rs
@@ -54,6 +54,7 @@ pub fn ical_to_ours(schedule: &mut Schedule, data: &[IcalEvent]) {
 					.as_ref()
 					.unwrap()
 					.to_string()
+					.replace("\n","")
 					.chars()
 					.skip(literal_header.len())
 					.collect::<String>();


### PR DESCRIPTION
This fixes handling of ical descriptions that contain line breaks, allowing us to use literal schedules again. Examples can be found on 10/6 and 10/13 (already set in calendar).