### PR TITLE
Formatting of /license output fails to compile

### DIFF
--- a/LICENSE.html
+++ b/LICENSE.html
@@ -9,7 +9,8 @@
       content="GNU Affero General Public License - GNU Project - Free Software Foundation (FSF)">
   </head>
   <body>
-    <article>
+		<i>The software with which you are currently communicating with was developed by {authors} and is released under the following license:</i>
+		<article>
       <h3 style="text-align: center;">GNU AFFERO GENERAL PUBLIC LICENSE</h3>
       <p style="text-align: center;">Version 3, 19 November 2007</p>
       <p>Copyright &copy; 2007 Free Software Foundation,


### PR DESCRIPTION
Fixes #82. Alternatively, one could remove the invocation of `format!` entirely.