### PR TITLE
Schedule color as homepage color

### DIFF
--- a/frontend/config/index.html
+++ b/frontend/config/index.html
@@ -1,93 +1,93 @@
 <!DOCTYPE html>
 <html lang="en">
-	<head>
-		<meta charset="UTF-8" />
-		<meta http-equiv="X-UA-Compatible" content="IE=edge" />
-		<meta name="viewport" content="width=device-width, initial-scale=1.0" />
-		<title>Schedule Uploader</title>
-		<link rel="stylesheet" href="../config/index.css" />
-		<include src="include/prelude.html"></include>
-		<script defer src="../config/schedule.js"></script>
-	</head>
 
-	<body class="background-color">
-		<include src="include/navbar.html"></include>
-		<div class="background">
-			<h2>Custom Schedule</h2>
-			<table>
-				<thead>
-					<tr>
-						<th>Period</th>
-						<th>Custom Name</th>
-						<th>Link</th>
-					</tr>
-				</thead>
-				<tbody id="cfg_body"></tbody>
-			</table>
-			<input type="checkbox" id="include_period_name" />
-			<label for="include_period_name"
-				>Include default period name when displaying<br />Example:
-				<b id="example_name">Loading...</b></label
-			>
-			<br />
-			<br />
-			<button id="save-schedule">Save Schedule</button>
-			<button id="reset-schedule">Reset Schedule</button>
-			<br />
-			<h2>Default Page</h2>
-			<div>
-				When you open the site, you will be redirected to the default
-				page.
-			</div>
-			<br />
-			<select name="Default Page" id="default-page">
-				<option value="/">Home</option>
-				<option value="/schedule">Schedule</option>
-				<option value="/timeline">Timeline</option>
-			</select>
-			<button id="save-default">Save Default Page</button>
-			<h2>Custom Colors</h2>
-			<label for="foreground_color">Foreground Color: </label>
-			<input type="color" id="foreground_color" />
-			<br />
-			<label for="background_color">Background Color: </label>
-			<input type="color" id="background_color" />
-			<br />
-			<label for="foreground_text_color">Foreground Text Color: </label>
-			<input type="color" id="foreground_text_color" />
-			<br />
-			<label for="background_text_color">Background Text Color: </label>
-			<input type="color" id="background_text_color" />
-			<br />
-			<br />
-			<button id="save-colors">Save Colors</button>
-			<button id="reset-colors">Reset Colors to Default</button>
-			<br />
-			<hr />
-			<h3>Export</h3>
-			<button id="download">Export Settings</button>
-			<h3>Import</h3>
-			<input type="file" id="cfg" />
-			<br />
-			<button id="upload" disabled>Import</button>
-			<br /><br />
-			<div id="instructions_toggle">
-				[Advanced] Click here for instructions to manually write a
-				config file
-			</div>
-			<div id="instructions">
-				<p>
-					You can make your own schedule file with a standard text
-					editor. A schedule file should look like this, omitting
-					content after "//".
-					<br />
-					<i
-						>(If you're not sure what this is, don't worry; this is
-						only useful for advanced users. You'll be able to get by
-						just fine with the editor above.)</i
-					>
-				</p>
-				<pre>
+<head>
+	<meta charset="UTF-8" />
+	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<title>Schedule Uploader</title>
+	<link rel="stylesheet" href="../config/index.css" />
+	<include src="include/prelude.html"></include>
+	<script defer src="../config/schedule.js"></script>
+</head>
+
+<body class="background-color">
+	<include src="include/navbar.html"></include>
+	<div class="background">
+		<h2>Custom Schedule</h2>
+		<table>
+			<thead>
+				<tr>
+					<th>Period</th>
+					<th>Custom Name</th>
+					<th>Link</th>
+				</tr>
+			</thead>
+			<tbody id="cfg_body"></tbody>
+		</table>
+		<input type="checkbox" id="include_period_name" />
+		<label for="include_period_name">Include default period name when displaying<br />Example:
+			<b id="example_name">Loading...</b></label>
+		<br />
+		<br />
+		<button id="save-schedule">Save Schedule</button>
+		<button id="reset-schedule">Reset Schedule</button>
+		<br />
+		<h2>Default Page</h2>
+		<div>
+			When you open the site, you will be redirected to the default
+			page.
+		</div>
+		<br />
+		<select name="Default Page" id="default-page">
+			<option value="/">Home</option>
+			<option value="/schedule">Schedule</option>
+			<option value="/timeline">Timeline</option>
+		</select>
+		<button id="save-default">Save Default Page</button>
+		<h2>Custom Colors</h2>
+		<label for="foreground_color">Foreground Color: </label>
+		<input type="color" id="foreground_color" />
+		<br />
+		<label for="background_color">Background Color: </label>
+		<input type="color" id="background_color" />
+		<br />
+		<label for="foreground_text_color">Foreground Text Color: </label>
+		<input type="color" id="foreground_text_color" />
+		<br />
+		<label for="background_text_color">Background Text Color: </label>
+		<input type="color" id="background_text_color" />
+		<br />
+		<label for="schedule_color_background">Use schedule color as background on homepage: </label>
+		<input type="checkbox" id="schedule_color_background" />
+		<br />
+		<br />
+		<button id="save-colors">Save Colors</button>
+		<button id="reset-colors">Reset Colors to Default</button>
+		<br />
+		<hr />
+		<h3>Export</h3>
+		<button id="download">Export Settings</button>
+		<h3>Import</h3>
+		<input type="file" id="cfg" />
+		<br />
+		<button id="upload" disabled>Import</button>
+		<br /><br />
+		<div id="instructions_toggle">
+			[Advanced] Click here for instructions to manually write a
+			config file
+		</div>
+		<div id="instructions">
+			<p>
+				You can make your own schedule file with a standard text
+				editor. A schedule file should look like this, omitting
+				content after "//".
+				<br />
+				<i>(If you're not sure what this is, don't worry; this is
+					only useful for advanced users. You'll be able to get by
+					just fine with the editor above.)</i>
+			</p>
+			<pre>
 {
 	"schedule": {
 		"EarlyBird": {
@@ -125,10 +125,10 @@
 	// This can be set to any URL, but ideally it should point to a path under our domain.
 	"default_page": "/timeline",
 	"include_period_name": false,
-}</pre
-				>
-			</div>
+}</pre>
 		</div>
-		<include src="include/advisory.html"></include>
-	</body>
+	</div>
+	<include src="include/advisory.html"></include>
+</body>
+
 </html>

--- a/frontend/config/schedule.js
+++ b/frontend/config/schedule.js
@@ -1,14 +1,5 @@
-const defaultConfig = {
-	schedule: {},
-	foreground_color: '#1a2741',
-	background_color: '#c34614',
-	foreground_text_color: '#ffffff',
-	background_text_color: '#ffffff',
-	include_period_name: true,
-};
-
 function getConfig() {
-	return Object.assign(defaultConfig, JSON.parse(localStorage.getItem('schedule')) || '{}');
+	return Object.assign(DEFAULT_CONFIG, JSON.parse(localStorage.getItem('schedule')) || '{}');
 }
 
 getel('upload').addEventListener('click', async () => {
@@ -55,6 +46,7 @@ function populate() {
 	getel('background_color').value = initial.background_color;
 	getel('foreground_text_color').value = initial.foreground_text_color;
 	getel('background_text_color').value = initial.background_text_color;
+	getel('schedule_color_background').checked = initial.use_schedule_color;
 	getel('default-page').value = initial.default_page || '/';
 	getel('cfg_body').innerHTML = [
 		{name: 'Early Bird', code: 'EarlyBird'},
@@ -134,6 +126,7 @@ getel('save-colors').addEventListener('click', () => {
 	data.background_color = getel('background_color').value;
 	data.foreground_text_color = getel('foreground_text_color').value;
 	data.background_text_color = getel('background_text_color').value;
+	data.use_schedule_color = getel('schedule_color_background').checked;
 
 	localStorage.setItem('schedule', JSON.stringify(data));
 	broadcastConfigToExtension();
@@ -165,6 +158,7 @@ getel('reset-colors').addEventListener('click', () => {
 	data.background_color = '#c34614';
 	data.foreground_text_color = '#ffffff';
 	data.background_text_color = '#ffffff';
+	data.use_schedule_color = true;
 
 	localStorage.setItem('schedule', JSON.stringify(data));
 	broadcastConfigToExtension();

--- a/frontend/editor/helpers.js
+++ b/frontend/editor/helpers.js
@@ -29,27 +29,7 @@ async function request(url, request, error_span) {
 	return result && result.ok;
 }
 
-function setCookie(name, value, expires, path = window.location.pathname) {
-	document.cookie = `${name}=${encodeURIComponent(value)}; ${
-		expires ? `expires=${new Date(expires).toUTCString()}; ` : ''
-	}path=${path}`;
-}
-
-function getCookie(name) {
-	return document.cookie.split('; ').reduce((r, v) => {
-		const parts = v.split('=');
-		return parts[0] === name ? decodeURIComponent(parts[1]) : r;
-	}, '');
-}
-
-function deleteCookie(name, path) {
-	setCookie(name, '', null, path);
-}
-
 Object.assign(window, {
 	$,
 	request,
-	setCookie,
-	getCookie,
-	deleteCookie,
 });

--- a/frontend/editor/index.html
+++ b/frontend/editor/index.html
@@ -6,6 +6,7 @@
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Schedule Editor</title>
+	<script src="../global/helpers.js"></script>
 	<script src="../editor/helpers.js"></script>
 	<script src="../editor/controls-section.js" defer></script>
 	<script src="../editor/auth-section.js" defer></script>

--- a/frontend/global/helpers.js
+++ b/frontend/global/helpers.js
@@ -10,6 +10,16 @@ if (!String.prototype.replaceAll) {
 	};
 }
 
+const DEFAULT_CONFIG = {
+	schedule: {},
+	foreground_color: '#1a2741',
+	background_color: '#c34614',
+	foreground_text_color: '#ffffff',
+	background_text_color: '#ffffff',
+	include_period_name: true,
+	use_schedule_color: true,
+};
+
 // Start helpers
 let lastFetchedData = null;
 const serverOffset = null;
@@ -25,15 +35,7 @@ async function get(endpoint = '/api/v1/today/now/near') {
 let config;
 function updateConfig() {
 	config = Object.assign(
-		{
-			schedule: {},
-			foreground_color: '#1a2741',
-			background_color: '#c34614',
-			foreground_text_color: '#ffffff',
-			background_text_color: '#ffffff',
-			include_period_name: true,
-			use_schedule_color: true,
-		},
+		DEFAULT_CONFIG,
 		JSON.parse(localStorage.getItem('schedule') || '{}'),
 	);
 	return config;
@@ -436,6 +438,7 @@ Object.assign(window, {
 	getCookie,
 	deleteCookie,
 	config,
+	DEFAULT_CONFIG,
 });
 
 // Writes a period to an element and its children

--- a/frontend/global/helpers.js
+++ b/frontend/global/helpers.js
@@ -32,6 +32,7 @@ function updateConfig() {
 			foreground_text_color: '#ffffff',
 			background_text_color: '#ffffff',
 			include_period_name: true,
+			use_schedule_color: true,
 		},
 		JSON.parse(localStorage.getItem('schedule') || '{}'),
 	);
@@ -336,34 +337,31 @@ window.addEventListener('load', () => {
 });
 
 function setTheme() {
-	const cfg = config;
+	const cfg = config || {};
+	const setBg = !(window.location.pathname === '/' && cfg.use_schedule_color);
 
 	document
 		.querySelector('meta[name=theme-color]')
-		.setAttribute('content', (cfg || {}).foreground_color || '#1a2741');
+		.setAttribute('content', cfg.foreground_color || '#1a2741');
 
-	if (!cfg) {
-		return;
-	}
-
-	if (cfg.background_color) {
+	if (setBg && cfg.background_color) {
 		document
 			.querySelector('body')
-			.style.setProperty('--background_color', cfg.background_color);
+			.style.setProperty('--background_color', cfg.background_color || '#c34614');
 	}
 
 	if (cfg.foreground_color) {
 		document
 			.querySelector('body')
-			.style.setProperty('--foreground_color', cfg.foreground_color);
+			.style.setProperty('--foreground_color', cfg.foreground_color || '#1a2741');
 	}
 
-	if (cfg.background_text_color) {
+	if (setBg && cfg.background_text_color) {
 		document
 			.querySelector('body')
 			.style.setProperty(
 				'--background_text_color',
-				cfg.background_text_color,
+				cfg.background_text_color || '#ffffff',
 			);
 	}
 
@@ -372,7 +370,7 @@ function setTheme() {
 			.querySelector('body')
 			.style.setProperty(
 				'--foreground_text_color',
-				cfg.foreground_text_color,
+				cfg.foreground_text_color || '#ffffff',
 			);
 	}
 }
@@ -388,6 +386,23 @@ function broadcastConfigToExtension() {
 			data: JSON.stringify(config),
 		});
 	}
+}
+
+function setCookie(name, value, expires, path = window.location.pathname) {
+	document.cookie = `${name}=${encodeURIComponent(value)}; ${
+		expires ? `expires=${new Date(expires).toUTCString()}; ` : ''
+	}path=${path}`;
+}
+
+function getCookie(name) {
+	return document.cookie.split('; ').reduce((r, v) => {
+		const parts = v.split('=');
+		return parts[0] === name ? decodeURIComponent(parts[1]) : r;
+	}, '');
+}
+
+function deleteCookie(name, path) {
+	setCookie(name, '', null, path);
 }
 
 broadcastConfigToExtension();
@@ -417,6 +432,10 @@ Object.assign(window, {
 	put_period_to_element,
 	setTheme,
 	broadcastConfigToExtension,
+	setCookie,
+	getCookie,
+	deleteCookie,
+	config,
 });
 
 // Writes a period to an element and its children

--- a/frontend/include/prelude.html
+++ b/frontend/include/prelude.html
@@ -1,18 +1,14 @@
 <!-- Primary Meta Tags -->
 <meta name="title" content="ETHSBell" />
-<meta
-	name="description"
-	content="ETHSBell is designed to help Evanston Township High School students be more familiar with the bell schedule and navigate their school day."
-/>
+<meta name="description"
+	content="ETHSBell is designed to help Evanston Township High School students be more familiar with the bell schedule and navigate their school day." />
 
 <!-- Open Graph / Facebook -->
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://ethsbell.app/" />
 <meta property="og:title" content="ETHSBell" />
-<meta
-	property="og:description"
-	content="ETHSBell is designed to help Evanston Township High School students be more familiar with the bell schedule and navigate their school day."
-/>
+<meta property="og:description"
+	content="ETHSBell is designed to help Evanston Township High School students be more familiar with the bell schedule and navigate their school day." />
 <meta property="og:image" content="/frontend/icon.png" />
 
 <meta name="theme-color" />

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,11 +9,11 @@
 	<link rel="stylesheet" href="index.css" />
 	<include src="include/prelude.html"></include>
 	<script defer src="global/progress.js"></script>
-	<script defer src="index.js"></script>
 	<script src="redirect.js"></script>
 </head>
 
 <body class="background-color">
+	<script src="index.js"></script>
 	<include src="include/navbar.html"></include>
 	<div id="wrapper" class="background-color">
 		<div class="big block text-center content">

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -106,15 +106,12 @@ function setColors(color) {
 	}
 
 	color ??= getCookie('schedule_color');
-	if (!color) {
-		return;
+	if (color) {
+		setCookie('schedule_color', color, new Date().setHours(24, 0, 0, 0));
 	}
 
-	setCookie('schedule_color', color, new Date().setHours(24, 0, 0, 0));
-	document.body.style.setProperty('--background_color', color);
-	// Document.body.style.setProperty('--foreground_color', 'unset');
-	document.body.style.setProperty('--background_text_color', black_or_white(color));
-	// Document.body.style.setProperty('--foreground_text_color', 'unset');
+	document.body.style.setProperty('--background_color', color || config.background_color);
+	document.body.style.setProperty('--background_text_color', color ? black_or_white(color) : config.background_text_color);
 }
 
 setColors();

--- a/frontend/index.js
+++ b/frontend/index.js
@@ -1,7 +1,7 @@
-const periodText = document.querySelector('#period');
-const endTimeText = document.querySelector('#end_time');
-const nextText = document.querySelector('#next');
-const schedulenameElement = document.querySelector('#schedulename');
+let periodText;
+let endTimeText;
+let nextText;
+let schedulenameElement;
 
 let lastData;
 // Gets data from /today/now/near
@@ -83,13 +83,13 @@ function display(data) {
 
 window.addEventListener('resize', () => display(lastData));
 
-go(display);
-
 async function schedule() {
 	const day = await get('/api/v1/today');
 	if (!day) {
 		return;
 	}
+
+	setColors(bytes_to_color(day.color));
 
 	if (day.periods.length > 0) {
 		schedulenameElement.innerHTML = `${day.friendly_name}`;
@@ -100,4 +100,31 @@ async function schedule() {
 	}
 }
 
-schedule();
+function setColors(color) {
+	if (!config.use_schedule_color) {
+		return;
+	}
+
+	color ??= getCookie('schedule_color');
+	if (!color) {
+		return;
+	}
+
+	setCookie('schedule_color', color, new Date().setHours(24, 0, 0, 0));
+	document.body.style.setProperty('--background_color', color);
+	// Document.body.style.setProperty('--foreground_color', 'unset');
+	document.body.style.setProperty('--background_text_color', black_or_white(color));
+	// Document.body.style.setProperty('--foreground_text_color', 'unset');
+}
+
+setColors();
+
+window.addEventListener('load', () => {
+	periodText = document.querySelector('#period');
+	endTimeText = document.querySelector('#end_time');
+	nextText = document.querySelector('#next');
+	schedulenameElement = document.querySelector('#schedulename');
+
+	go(display);
+	schedule();
+});

--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
 			"getCookie",
 			"setCookie",
 			"request",
-			"pull"
+			"pull",
+			"config"
 		],
 		"rules": {
 			"camelcase": 0,

--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
 			"setCookie",
 			"request",
 			"pull",
-			"config"
+			"config",
+			"DEFAULT_CONFIG"
 		],
 		"rules": {
 			"camelcase": 0,


### PR DESCRIPTION
The schedule color will be used as the background color on the homepage. This can be configured on the settings page and is enabled by default.

The colors are cached in a cookie for the day, which should avoid a style flicker for subsequent page loads.