### PR TITLE
`/today/now/near` v2: support multiple previous & future periods

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,7 +69,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -80,7 +80,7 @@ checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -91,9 +91,9 @@ checksum = "c59bdb34bc650a32731b31bd8f0829cc15d24a708ee31559e0bb34f2bc320cba"
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
@@ -111,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
@@ -181,15 +181,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "bytes"
@@ -199,9 +199,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.2.26"
+version = "1.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "956a5e21988b87f372569b66183b78babf23ebc2e744b733e4350a752c4dafac"
+checksum = "2352e5597e9c544d5e6d9c95190d5d27738ade584fa8db0a16e130e5c2b5296e"
 dependencies = [
  "shlex",
 ]
@@ -214,9 +214,9 @@ checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "chrono"
-version = "0.4.41"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -224,7 +224,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -424,7 +424,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -445,14 +445,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -477,12 +477,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -522,7 +522,7 @@ version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
- "atomic 0.6.0",
+ "atomic 0.6.1",
  "pear",
  "serde",
  "toml",
@@ -702,9 +702,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glob"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -732,9 +732,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
 dependencies = [
  "bytes",
  "fnv",
@@ -742,7 +742,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -757,9 +757,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -781,9 +781,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -845,7 +845,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -1031,12 +1031,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1066,6 +1066,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1077,7 +1088,7 @@ version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -1126,9 +1137,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libm"
@@ -1138,9 +1149,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.3"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
  "bitflags 2.9.1",
  "libc",
@@ -1201,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "mime"
@@ -1338,7 +1349,7 @@ version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi 0.5.2",
  "libc",
 ]
 
@@ -1403,7 +1414,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1482,7 +1493,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1493,20 +1504,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror 2.0.12",
+ "thiserror 2.0.14",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1514,24 +1525,23 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
 dependencies = [
- "once_cell",
  "pest",
  "sha2",
 ]
@@ -1642,9 +1652,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
 ]
@@ -1657,7 +1667,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -1687,9 +1697,9 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.2.0"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
@@ -1723,9 +1733,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.12"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.1",
 ]
@@ -1747,7 +1757,7 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -1885,7 +1895,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rocket_http",
- "syn 2.0.102",
+ "syn 2.0.105",
  "unicode-xid",
 ]
 
@@ -1970,21 +1980,21 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1998,9 +2008,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
@@ -2049,7 +2059,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2104,7 +2114,7 @@ checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2115,14 +2125,14 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -2189,9 +2199,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -2204,12 +2214,9 @@ checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "slug"
@@ -2235,6 +2242,16 @@ checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2326,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.102"
+version = "2.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6397daf94fa90f058bd0fd88429dd9e5738999cca8d701813c80723add80462"
+checksum = "7bc3fcb250e53458e712715cf74285c1f889686520d79294a9ef3bd7aa1fc619"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2349,7 +2366,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2428,11 +2445,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
+checksum = "0b0949c3a6c842cbde3f1686d6eea5a010516deb7085f79db747562d4102f41e"
 dependencies = [
- "thiserror-impl 2.0.12",
+ "thiserror-impl 2.0.14",
 ]
 
 [[package]]
@@ -2443,28 +2460,27 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.12"
+version = "2.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
+checksum = "cc5b44b4ab9c2fdd0e0512e6bece8388e214c0749f5862b114cc5b7a25daf227"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
@@ -2510,19 +2526,21 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.45.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.4",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2533,7 +2551,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2559,9 +2577,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.15"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -2597,7 +2615,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.9.0",
+ "indexmap 2.10.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2630,13 +2648,13 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.29"
+version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1ffbcf9c6f6b99d386e7444eb608ba646ae452a36b39737deb9663b610f662"
+checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -2892,7 +2910,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
  "wasm-bindgen-shared",
 ]
 
@@ -2927,7 +2945,7 @@ checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3012,7 +3030,7 @@ checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3023,14 +3041,14 @@ checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
 name = "windows-result"
@@ -3087,6 +3105,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,11 +3152,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3151,6 +3195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3167,6 +3217,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3187,10 +3243,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3211,6 +3279,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3227,6 +3301,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3247,6 +3327,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3265,10 +3351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.7.10"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
@@ -3330,28 +3422,28 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]
 
 [[package]]
@@ -3371,7 +3463,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
  "synstructure",
 ]
 
@@ -3388,9 +3480,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -3405,5 +3497,5 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.102",
+ "syn 2.0.105",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rocket_dyn_templates = { version = "=0.1.0-rc.3", optional = true, features = [
 ] }
 serde = { version = "1.0.125", features = ["derive"] }
 serde_json = "1.0.64"
-chrono = { version = "0.4.19", features = ["serde"] }
+chrono = { version = "=0.4.34", features = ["serde"] }
 reqwest = { version = "0.11.3", features = ["blocking"], optional = true }
 serde_regex = "1.1.0"
 regex = "1.4.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,11 @@
 {
 	"name": "ethsbell-rewrite",
+	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
+			"version": "0.0.1",
 			"devDependencies": {
 				"create-polyfill-service-url": "^2.2.6",
 				"eslint-config-xo": "^0.37.0",
@@ -11,8 +13,7 @@
 				"parcel": "^2.0.1",
 				"posthtml-include": "^1.7.2",
 				"xo": "^0.46.4"
-			},
-			"version": "0.0.1"
+			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
 			"version": "1.2.6",
@@ -10894,16 +10895,12 @@
 			}
 		},
 		"node_modules/xo/node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+			"version": "3.0.0",
 			"dev": true,
 			"inBundle": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/xo/node_modules/eslint/node_modules/@eslint/eslintrc": {
@@ -19159,9 +19156,7 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "3.4.3",
-					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
-					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -19540,6 +19535,5 @@
 			"integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
 			"dev": true
 		}
-	},
-	"version": "0.0.1"
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,9 @@
 {
 	"name": "ethsbell-rewrite",
-	"version": "0.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
-			"version": "0.0.1",
 			"devDependencies": {
 				"create-polyfill-service-url": "^2.2.6",
 				"eslint-config-xo": "^0.37.0",
@@ -13,7 +11,8 @@
 				"parcel": "^2.0.1",
 				"posthtml-include": "^1.7.2",
 				"xo": "^0.46.4"
-			}
+			},
+			"version": "0.0.1"
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
 			"version": "1.2.6",
@@ -10895,12 +10894,16 @@
 			}
 		},
 		"node_modules/xo/node_modules/eslint-visitor-keys": {
-			"version": "3.0.0",
+			"version": "3.4.3",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"inBundle": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/xo/node_modules/eslint/node_modules/@eslint/eslintrc": {
@@ -19156,7 +19159,9 @@
 					}
 				},
 				"eslint-visitor-keys": {
-					"version": "3.0.0",
+					"version": "3.4.3",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+					"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 					"bundled": true,
 					"dev": true
 				},
@@ -19535,5 +19540,6 @@
 			"integrity": "sha512-AyeEbWOu/TAXdxlV9wmGcR0+yh2j3vYPGOECcIj2S7MkrLyC7ne+oye2BKTItt0ii2PHk4cDy+95+LshzbXnGg==",
 			"dev": true
 		}
-	}
+	},
+	"version": "0.0.1"
 }

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -8,6 +8,20 @@ pub mod v1 {
 /// Type aliases for API V2
 pub mod v2 {
 	use crate::schedule::Period;
+	use serde::Serialize;
+	use schemars::JsonSchema;
+
 	/// This is the type of the data returned by /api/v2/today/now/near.
-	pub type NearbyPeriods = (Vec<Period>, Vec<Period>, Vec<Period>);
+	/// The periods returned by `previous` and `future` will have either the
+	/// same end time (for `previous`) or the same start time (for `future`)
+	/// if there are multiple periods.
+	#[derive(Serialize, JsonSchema)]
+	pub struct NearbyPeriods {
+		/// The `Period`(s) that occurred before this one
+		pub previous: Vec<Period>,
+		/// The `Period`(s) that are going on right now
+		pub current: Vec<Period>,
+		/// The `Period`(s) that will occur after this one
+		pub future: Vec<Period>,
+	}
 }

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -8,16 +8,16 @@ pub mod v1 {
 /// Type aliases for API V2
 pub mod v2 {
 	use crate::schedule::Period;
-	use serde::Serialize;
 	#[cfg(feature = "ws")]
 	use schemars::JsonSchema;
+	use serde::{Deserialize, Serialize};
 
 	/// This is the type of the data returned by /api/v2/today/now/near.
 	/// The periods returned by `previous` and `future` will have either the
 	/// same end time (for `previous`) or the same start time (for `future`)
 	/// if there are multiple periods.
 	#[cfg_attr(feature = "ws", derive(JsonSchema))]
-	#[derive(Serialize)]
+	#[derive(Serialize, Deserialize, PartialEq, Debug)]
 	pub struct NearbyPeriods {
 		/// The `Period`(s) that occurred before this one
 		pub previous: Vec<Period>,

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -9,13 +9,15 @@ pub mod v1 {
 pub mod v2 {
 	use crate::schedule::Period;
 	use serde::Serialize;
+	#[cfg(feature = "ws")]
 	use schemars::JsonSchema;
 
 	/// This is the type of the data returned by /api/v2/today/now/near.
 	/// The periods returned by `previous` and `future` will have either the
 	/// same end time (for `previous`) or the same start time (for `future`)
 	/// if there are multiple periods.
-	#[derive(Serialize, JsonSchema)]
+	#[cfg_attr(feature = "ws", derive(JsonSchema))]
+	#[derive(Serialize)]
 	pub struct NearbyPeriods {
 		/// The `Period`(s) that occurred before this one
 		pub previous: Vec<Period>,

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -9,5 +9,5 @@ pub mod v1 {
 pub mod v2 {
 	use crate::schedule::Period;
 	/// This is the type of the data returned by /api/v2/today/now/near.
-	pub type NearbyPeriods = (Vec<Period>, Vec<Period>, Option<Period>);
+	pub type NearbyPeriods = (Vec<Period>, Vec<Period>, Vec<Period>);
 }

--- a/src/aliases.rs
+++ b/src/aliases.rs
@@ -4,3 +4,10 @@ pub mod v1 {
 	/// This is the type of the data returned by /api/v1/today/now/near.
 	pub type NearbyPeriods = (Option<Period>, Vec<Period>, Option<Period>);
 }
+
+/// Type aliases for API V2
+pub mod v2 {
+	use crate::schedule::Period;
+	/// This is the type of the data returned by /api/v2/today/now/near.
+	pub type NearbyPeriods = (Vec<Period>, Vec<Period>, Option<Period>);
+}

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -42,7 +42,7 @@ impl Fairing for ApiFairing {
 		rocket: rocket::Rocket<Build>,
 	) -> Result<rocket::Rocket<Build>, rocket::Rocket<Build>> {
 		Ok(rocket
-		    .mount("/api/v2", v2::routes())
+			.mount("/api/v2", v2::routes())
 			.mount("/api/v1", v1::routes())
 			.mount("/api/legacy", legacy::routes())
 			.mount(

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -20,6 +20,7 @@ use crate::login::WantsBasicAuth;
 #[cfg(feature = "ws")]
 pub mod legacy;
 pub mod v1;
+pub mod v2;
 
 /// This struct is used as a Rocket Fairing and adds our API endpoints.
 #[cfg(feature = "ws")]
@@ -41,8 +42,16 @@ impl Fairing for ApiFairing {
 		rocket: rocket::Rocket<Build>,
 	) -> Result<rocket::Rocket<Build>, rocket::Rocket<Build>> {
 		Ok(rocket
+		    .mount("/api/v2", v2::routes())
 			.mount("/api/v1", v1::routes())
 			.mount("/api/legacy", legacy::routes())
+			.mount(
+				"/docs/v2",
+				make_swagger_ui(&SwaggerUIConfig {
+					url: "../../api/v2/openapi.json".to_owned(),
+					..Default::default()
+				}),
+			)
 			.mount(
 				"/docs/v1",
 				make_swagger_ui(&SwaggerUIConfig {

--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "ws"))]
 use crate::api::{Json, State};
-use crate::{aliases::v1::NearbyPeriods, schedule::{Schedule}};
+use crate::{aliases::v2::NearbyPeriods, schedule::{Schedule}};
 use chrono::{Local, NaiveDateTime, TimeZone};
 #[cfg(feature = "ws")]
 use rocket::serde::json::Json;
@@ -45,7 +45,10 @@ pub fn today_around_now(
 	let now_time = now.time();
 	let schedule = schedule.read().unwrap().on_date(now_date);
 	let mut schedule = schedule.0.at_time_v2(now_time);
-	schedule.0 = schedule.0.map(|v| v.populate(now));
+	schedule
+        .0
+        .iter_mut()
+		.for_each(|v| *v = v.clone().populate(now));
 	schedule
 		.1
 		.iter_mut()

--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -4,7 +4,7 @@
 
 #[cfg(not(feature = "ws"))]
 use crate::api::{Json, State};
-use crate::{aliases::v2::NearbyPeriods, schedule::{Schedule}};
+use crate::{aliases::v2::NearbyPeriods, schedule::Schedule};
 use chrono::{Local, NaiveDateTime, TimeZone};
 #[cfg(feature = "ws")]
 use rocket::serde::json::Json;
@@ -12,7 +12,7 @@ use rocket::serde::json::Json;
 use rocket::{Route, State};
 #[cfg(feature = "ws")]
 use rocket_okapi::openapi;
-use std::{sync::{Arc, RwLock}};
+use std::sync::{Arc, RwLock};
 
 #[cfg(feature = "ws")]
 #[must_use]
@@ -46,16 +46,16 @@ pub fn today_around_now(
 	let schedule = schedule.read().unwrap().on_date(now_date);
 	let mut schedule = schedule.0.at_time_v2(now_time);
 	schedule
-        .0
-        .iter_mut()
+		.0
+		.iter_mut()
 		.for_each(|v| *v = v.clone().populate(now));
 	schedule
 		.1
 		.iter_mut()
 		.for_each(|v| *v = v.clone().populate(now));
 	schedule
-        .2
-    	.iter_mut()
-    	.for_each(|v| *v = v.clone().populate(now));
+		.2
+		.iter_mut()
+		.for_each(|v| *v = v.clone().populate(now));
 	Json(schedule)
 }

--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -53,6 +53,9 @@ pub fn today_around_now(
 		.1
 		.iter_mut()
 		.for_each(|v| *v = v.clone().populate(now));
-	schedule.2 = schedule.2.map(|v| v.populate(now));
+	schedule
+        .2
+    	.iter_mut()
+    	.for_each(|v| *v = v.clone().populate(now));
 	Json(schedule)
 }

--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -57,5 +57,10 @@ pub fn today_around_now(
 		.2
 		.iter_mut()
 		.for_each(|v| *v = v.clone().populate(now));
-	Json(schedule)
+
+	Json(NearbyPeriods {
+		previous: schedule.0,
+		current: schedule.1,
+		future: schedule.2,
+	})
 }

--- a/src/api/v2.rs
+++ b/src/api/v2.rs
@@ -1,0 +1,55 @@
+#![allow(missing_docs)]
+#![allow(non_snake_case)]
+#![allow(clippy::let_unit_value)]
+
+#[cfg(not(feature = "ws"))]
+use crate::api::{Json, State};
+use crate::{aliases::v1::NearbyPeriods, schedule::{Schedule}};
+use chrono::{Local, NaiveDateTime, TimeZone};
+#[cfg(feature = "ws")]
+use rocket::serde::json::Json;
+#[cfg(feature = "ws")]
+use rocket::{Route, State};
+#[cfg(feature = "ws")]
+use rocket_okapi::openapi;
+use std::{sync::{Arc, RwLock}};
+
+#[cfg(feature = "ws")]
+#[must_use]
+/// Generates a list of Routes for Rocket
+pub fn routes() -> Vec<Route> {
+	use rocket_okapi::settings::OpenApiSettings;
+	let settings = OpenApiSettings::new();
+	let spec = rocket_okapi::openapi_spec![today_around_now](&settings);
+	#[allow(unused_mut)]
+	let mut r = rocket_okapi::openapi_routes![today_around_now](Some(spec), &settings);
+	r
+}
+
+/// Returns the current period type and its neighbors.
+#[cfg_attr(feature = "ws", openapi)]
+#[cfg_attr(feature = "ws", get("/today/now/near?<timestamp>"))]
+#[must_use]
+pub fn today_around_now(
+	schedule: &State<Arc<RwLock<Schedule>>>,
+	timestamp: Option<i64>,
+) -> Json<NearbyPeriods> {
+	Schedule::update_if_needed_async(schedule.inner().clone());
+	let now = match timestamp {
+		None => Local::now(),
+		Some(timestamp) => Local
+			.from_utc_datetime(&NaiveDateTime::from_timestamp_opt(timestamp, 0).unwrap_or_default())
+			.with_timezone(&Local),
+	};
+	let now_date = now.date_naive();
+	let now_time = now.time();
+	let schedule = schedule.read().unwrap().on_date(now_date);
+	let mut schedule = schedule.0.at_time_v2(now_time);
+	schedule.0 = schedule.0.map(|v| v.populate(now));
+	schedule
+		.1
+		.iter_mut()
+		.for_each(|v| *v = v.clone().populate(now));
+	schedule.2 = schedule.2.map(|v| v.populate(now));
+	Json(schedule)
+}

--- a/src/impls.rs
+++ b/src/impls.rs
@@ -20,7 +20,7 @@ where
 		let mut max_val = None;
 
 		while let Some(val) = self.next() {
-			if max_val.as_ref().map_or(true, |m| &val > m) {
+			if max_val.as_ref().is_none_or(|m| &val > m) {
 				max_iter = self.clone();
 				max_val = Some(val);
 			}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@
 #![allow(clippy::needless_pass_by_value)]
 #![allow(clippy::missing_panics_doc)]
 #![allow(clippy::too_many_lines)]
+#![allow(unused_imports)]
 
 //! `ETHSBell` is a web-based bell schedule tracker.
 pub use locks::SpecLock;

--- a/src/schedule/schedule_type.rs
+++ b/src/schedule/schedule_type.rs
@@ -103,6 +103,87 @@ impl ScheduleType {
 			)
 		}
 	}
+
+	/// Returns a tuple of a Vec<Period> of the previous Periods, a Vec<Period> of the current periods,
+	/// and a Vec<Period> of the next periods.
+	#[must_use]
+	pub fn at_time_v2(&self, time: NaiveTime) -> (Option<Period>, Vec<Period>, Option<Period>) {
+		if self.periods.is_empty() {
+			(None, vec![], None)
+		} else {
+			let mut before: Option<Period> = None;
+			let mut current: Vec<Period> = vec![];
+			let mut next: Option<Period> = None;
+			self.periods.iter().for_each(|period| {
+				if period.end <= time {
+					if period.kind != PeriodType::Passing {
+						match before.clone() {
+							Some(before_) if before_.end < period.end => {
+								before = Some(period.clone());
+							}
+							None => before = Some(period.clone()),
+							_ => {}
+						}
+					}
+				} else if period.start > time {
+					if period.kind != PeriodType::Passing {
+						match next.clone() {
+							Some(next_) if next_.start > period.start => {
+								next = Some(period.clone());
+							}
+							None => next = Some(period.clone()),
+							_ => {}
+						}
+					}
+				} else {
+					current.push(period.clone());
+				}
+			});
+			match (&before, &current, &next) {
+				(Some(before), v, Some(next)) if v.is_empty() => {
+					current = vec![Period {
+						friendly_name: "Passing Period".to_string(),
+						start: before.end,
+						end: next.start,
+						start_timestamp: 0,
+						end_timestamp: 0,
+						kind: PeriodType::Passing,
+					}];
+				}
+				(None, v, Some(next)) if v.is_empty() => {
+					current = vec![Period {
+						friendly_name: "Before School".to_string(),
+						start: NaiveTime::from_hms_opt(0, 0, 0).unwrap_or_default(),
+						end: next.start,
+						start_timestamp: 0,
+						end_timestamp: 0,
+						kind: PeriodType::BeforeSchool,
+					}];
+				}
+				(Some(before), v, None) if v.is_empty() => {
+					current = vec![Period {
+						friendly_name: "After School".to_string(),
+						start: before.end,
+						end: NaiveTime::from_hms_opt(23, 59, 59).unwrap_or_default(),
+						start_timestamp: 0,
+						end_timestamp: 0,
+						kind: PeriodType::AfterSchool,
+					}];
+				}
+				_ => {}
+			}
+			let now = Local::now();
+			(
+				before.map(|v| v.populate(now)),
+				current
+					.iter()
+					.map(|v| v.clone().populate(now))
+					.collect::<Vec<Period>>(),
+				next.map(|v| v.populate(now)),
+			)
+		}
+	}
+
 	/// Returns the first period of the schedule with the kind Class(_).
 	#[must_use]
 	pub fn first_class(&self) -> Option<Period> {

--- a/src/schedule/schedule_type.rs
+++ b/src/schedule/schedule_type.rs
@@ -111,27 +111,27 @@ impl ScheduleType {
 		if self.periods.is_empty() {
 			(None, vec![], None)
 		} else {
-			let mut before: Option<Period> = None;
+			let mut previous: Option<Period> = None;
 			let mut current: Vec<Period> = vec![];
-			let mut next: Option<Period> = None;
+			let mut future: Option<Period> = None;
 			self.periods.iter().for_each(|period| {
 				if period.end <= time {
 					if period.kind != PeriodType::Passing {
-						match before.clone() {
+						match previous.clone() {
 							Some(before_) if before_.end < period.end => {
-								before = Some(period.clone());
+								previous = Some(period.clone());
 							}
-							None => before = Some(period.clone()),
+							None => previous = Some(period.clone()),
 							_ => {}
 						}
 					}
 				} else if period.start > time {
 					if period.kind != PeriodType::Passing {
-						match next.clone() {
+						match future.clone() {
 							Some(next_) if next_.start > period.start => {
-								next = Some(period.clone());
+								future = Some(period.clone());
 							}
-							None => next = Some(period.clone()),
+							None => future = Some(period.clone()),
 							_ => {}
 						}
 					}
@@ -139,7 +139,7 @@ impl ScheduleType {
 					current.push(period.clone());
 				}
 			});
-			match (&before, &current, &next) {
+			match (&previous, &current, &future) {
 				(Some(before), v, Some(next)) if v.is_empty() => {
 					current = vec![Period {
 						friendly_name: "Passing Period".to_string(),
@@ -174,12 +174,12 @@ impl ScheduleType {
 			}
 			let now = Local::now();
 			(
-				before.map(|v| v.populate(now)),
+				previous.map(|v| v.populate(now)),
 				current
 					.iter()
 					.map(|v| v.clone().populate(now))
 					.collect::<Vec<Period>>(),
-				next.map(|v| v.populate(now)),
+				future.map(|v| v.populate(now)),
 			)
 		}
 	}

--- a/src/schedule/schedule_type.rs
+++ b/src/schedule/schedule_type.rs
@@ -121,28 +121,28 @@ impl ScheduleType {
 					if period.kind != PeriodType::Passing {
 						match previous.get(0).clone() {
 							Some(before) => {
-    							if period.end > before.end {
-                                    // if we find a more recent period, replace everything
-    								previous = vec![period.clone()];
-    							} else if period.end == before.end {
-                                    // if we find a matching end time, add it
-                                    previous.push(period.clone());
-                                }
+								if period.end > before.end {
+									// if we find a more recent period, replace everything
+									previous = vec![period.clone()];
+								} else if period.end == before.end {
+									// if we find a matching end time, add it
+									previous.push(period.clone());
+								}
 							}
-							None => previous.push(period.clone())
+							None => previous.push(period.clone()),
 						}
 					}
 				} else if period.start > time {
 					if period.kind != PeriodType::Passing {
 						match future.get(0).clone() {
 							Some(after) => {
-    							if period.start < after.start {
-    								future = vec![period.clone()];
-    							} else if period.start == after.start {
-                                    future.push(period.clone());
-                                }
+								if period.start < after.start {
+									future = vec![period.clone()];
+								} else if period.start == after.start {
+									future.push(period.clone());
+								}
 							}
-							None => future.push(period.clone())
+							None => future.push(period.clone()),
 						}
 					}
 				} else {
@@ -152,56 +152,56 @@ impl ScheduleType {
 
 			// add implicit periods
 			if current.is_empty() {
-    			match (previous.is_empty(), future.is_empty()) {
-    				(false, false) => {
-    					current = vec![Period {
-    						friendly_name: "Passing Period".to_string(),
-    						start: previous[0].end,
-    						end: future[0].start,
-    						start_timestamp: 0,
-    						end_timestamp: 0,
-    						kind: PeriodType::Passing,
-    					}];
-    				}
-    				(true, false) => {
-    					current = vec![Period {
-    						friendly_name: "Before School".to_string(),
-    						start: NaiveTime::from_hms_opt(0, 0, 0).unwrap_or_default(),
-    						end: future[0].start,
-    						start_timestamp: 0,
-    						end_timestamp: 0,
-    						kind: PeriodType::BeforeSchool,
-    					}];
-    				}
-    				(false, true) => {
-    					current = vec![Period {
-    						friendly_name: "After School".to_string(),
-    						start: previous[0].end,
-    						end: NaiveTime::from_hms_opt(23, 59, 59).unwrap_or_default(),
-    						start_timestamp: 0,
-    						end_timestamp: 0,
-    						kind: PeriodType::AfterSchool,
-    					}];
-    				}
-    				_ => {}
-    			}
+				match (previous.is_empty(), future.is_empty()) {
+					(false, false) => {
+						current = vec![Period {
+							friendly_name: "Passing Period".to_string(),
+							start: previous[0].end,
+							end: future[0].start,
+							start_timestamp: 0,
+							end_timestamp: 0,
+							kind: PeriodType::Passing,
+						}];
+					}
+					(true, false) => {
+						current = vec![Period {
+							friendly_name: "Before School".to_string(),
+							start: NaiveTime::from_hms_opt(0, 0, 0).unwrap_or_default(),
+							end: future[0].start,
+							start_timestamp: 0,
+							end_timestamp: 0,
+							kind: PeriodType::BeforeSchool,
+						}];
+					}
+					(false, true) => {
+						current = vec![Period {
+							friendly_name: "After School".to_string(),
+							start: previous[0].end,
+							end: NaiveTime::from_hms_opt(23, 59, 59).unwrap_or_default(),
+							start_timestamp: 0,
+							end_timestamp: 0,
+							kind: PeriodType::AfterSchool,
+						}];
+					}
+					_ => {}
+				}
 			}
 
 			// populate timestamps
 			let now = Local::now();
 			(
 				previous
-				    .iter()
-    				.map(|v| v.clone().populate(now))
-    				.collect::<Vec<Period>>(),
+					.iter()
+					.map(|v| v.clone().populate(now))
+					.collect::<Vec<Period>>(),
 				current
 					.iter()
 					.map(|v| v.clone().populate(now))
 					.collect::<Vec<Period>>(),
 				future
-                    .iter()
-    				.map(|v| v.clone().populate(now))
-    				.collect::<Vec<Period>>(),
+					.iter()
+					.map(|v| v.clone().populate(now))
+					.collect::<Vec<Period>>(),
 			)
 		}
 	}

--- a/src/schedule/schedule_type.rs
+++ b/src/schedule/schedule_type.rs
@@ -119,7 +119,7 @@ impl ScheduleType {
 			self.periods.iter().for_each(|period| {
 				if period.end <= time {
 					if period.kind != PeriodType::Passing {
-						match previous.get(0).clone() {
+						match previous.first() {
 							Some(before) => {
 								if period.end > before.end {
 									// if we find a more recent period, replace everything
@@ -134,7 +134,7 @@ impl ScheduleType {
 					}
 				} else if period.start > time {
 					if period.kind != PeriodType::Passing {
-						match future.get(0).clone() {
+						match future.first() {
 							Some(after) => {
 								if period.start < after.start {
 									future = vec![period.clone()];

--- a/tests/api_v2.rs
+++ b/tests/api_v2.rs
@@ -1,0 +1,116 @@
+#![cfg(feature = "ws")]
+#![allow(clippy::too_many_lines)]
+
+use chrono::{Local, NaiveDateTime};
+use ethsbell_rewrite::{
+	aliases::v2::NearbyPeriods,
+	rocket_builder::rocket,
+	schedule::{Period, PeriodType, Schedule, ScheduleType},
+};
+use rocket::{
+	async_test,
+	http::{ContentType, Status},
+	local::asynchronous::Client,
+};
+
+async fn client(schedule: Schedule) -> Client {
+	Client::tracked(rocket(schedule)).await.unwrap()
+}
+
+#[async_test]
+async fn now_near() {
+	let mut schedule = Schedule::default();
+	// Add test A
+	let period_now = Period {
+		friendly_name: "Block 2".to_string(),
+		start: {
+			let now = Local::now().naive_local().timestamp() - 10;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		start_timestamp: 0,
+		end: {
+			let now = Local::now().naive_local().timestamp() + 10;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		end_timestamp: 0,
+		kind: PeriodType::Class(String::new()),
+	};
+	let period_before_1 = Period {
+		friendly_name: "Block 1A".to_string(),
+		start: {
+			let now = Local::now().naive_local().timestamp() - 30;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		start_timestamp: 0,
+		end: {
+			let now = Local::now().naive_local().timestamp() - 20;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		end_timestamp: 0,
+		kind: PeriodType::Class(String::new()),
+	};
+	let mut period_before_2 = period_before_1.clone();
+	period_before_2.friendly_name = "Block 1B".to_string();
+	let period_after = Period {
+		friendly_name: "Block 3".to_string(),
+		start: {
+			let now = Local::now().naive_local().timestamp() + 20;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		start_timestamp: 0,
+		end: {
+			let now = Local::now().naive_local().timestamp() + 30;
+			NaiveDateTime::from_timestamp_opt(now, 0)
+				.unwrap_or_default()
+				.time()
+		},
+		end_timestamp: 0,
+		kind: PeriodType::Class(String::new()),
+	};
+	let test_a = ScheduleType {
+		hide: false,
+		friendly_name: "Test A".to_string(),
+		periods: vec![
+			period_before_1.clone(),
+			period_before_2.clone(),
+			period_now.clone(),
+			period_after.clone(),
+		],
+		regex: None,
+		color: Some([0, 0, 0]),
+	};
+	schedule
+		.definition
+		.schedule_types
+		.insert("test_a".to_string(), test_a);
+	// Build typical schedule
+	schedule.definition.typical_schedule = vec!["test_a".to_string(); 7];
+	let client = client(schedule.clone()).await;
+	// Check test A
+	let response = client.get("/api/v2/today/now/near").dispatch().await;
+	assert_eq!(response.status(), Status::Ok);
+	assert_eq!(response.content_type(), Some(ContentType::JSON));
+	let json_string = &response.into_string().await.unwrap();
+	println!("API response: {json_string}");
+	let response: NearbyPeriods = serde_json::from_str(json_string).unwrap();
+	println!("Deserialized: {response:?}");
+
+	assert_eq!(
+		response,
+		NearbyPeriods {
+			previous: vec![period_before_1, period_before_2],
+			current: vec![period_now],
+			future: vec![period_after]
+		}
+	);
+}


### PR DESCRIPTION
## What
This pull request creates a new API version, v2, with a single route: `/today/now/near`.
This updated route differs from its v1 counterpart in that it's able to return multiple upcoming and previous periods, rather than just one.
The new API version is necessary since this is a breaking change.

Fixes #113 

## Motivation
This is especially useful when considering cases when there are two periods beginning at the same time, like the current blocks 5 and 6. Ex:
<img width="635" height="262" alt="image" src="https://github.com/user-attachments/assets/04807534-7f79-4ff4-ba70-8c045a6bf9ce" />
In such cases, the v1 API might only return a single lunch block for the future periods, which creates an edge case where the other block, like block 5A, for example, could never be displayed as an upcoming period by any consuming application without awkward workarounds.

## Behavior
The behavior is mostly the same as with the old endpoint, with the main difference being that previous and future periods are always given as an array, and may contain multiple periods if there are periods that either start or end concurrently.